### PR TITLE
Fixes for Docker containers on Linux

### DIFF
--- a/basic/gnmi-cli.sh
+++ b/basic/gnmi-cli.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-docker run -it --rm bocon/gnmi-cli \
-  --grpc-addr host.docker.internal:50001 $@
+docker run -it --rm \
+  --network=host \
+  bocon/gnmi-cli \
+  --grpc-addr 127.0.0.1:50001 $@

--- a/basic/netcfg.sh
+++ b/basic/netcfg.sh
@@ -2,4 +2,4 @@
 
 #FIXME update netcfg file to path based on location of this shell script
 
-curl -sSL --user onos:rocks --noproxy localhost -X POST -H 'Content-Type:application/json' http://localhost:8181/onos/v1/network/configuration/ -d@netcfg-3switch.json
+curl -sSL --user onos:rocks --noproxy localhost -X POST -H 'Content-Type:application/json' http://localhost:8181/onos/v1/network/configuration/ -d@netcfg.json

--- a/basic/p4rt-shell.sh
+++ b/basic/p4rt-shell.sh
@@ -4,7 +4,8 @@
 
 docker run -it --rm \
   -v $PWD/cfg:/tmp/cfg \
+  --network=host \
   p4lang/p4runtime-sh \
-  --grpc-addr host.docker.internal:50001 \
+  --grpc-addr 127.0.0.1:50001 \
   --device-id 1 --election-id 0,1 \
   --config /tmp/cfg/basic_p4info.txt,/tmp/cfg/basic.json

--- a/basic/start-onos.sh
+++ b/basic/start-onos.sh
@@ -3,4 +3,4 @@
 docker run -it --rm \
   -e ONOS_APPS=gui2,drivers.bmv2,pipelines.basic,lldpprovider,hostprovider,fwd \
   -p 8101:8101 -p 8181:8181 \
-  onosproject/onos:2.1.0
+  onosproject/onos:2.2.x

--- a/trellis/Makefile
+++ b/trellis/Makefile
@@ -5,7 +5,7 @@ dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 start-mn:
 	docker run --privileged --rm -it \
 	  -v /tmp/mn-stratum:/tmp \
-          -v ${dir}topo.py:/root/topo.py \
+	  -v ${dir}topo.py:/root/topo.py \
 	  -p 50001-50030:50001-50030 \
 	  opennetworking/mn-stratum --mac --custom /root/topo.py --topo trellis	
 
@@ -13,7 +13,7 @@ start-onos:
 	docker run -it --rm \
 	  -e ONOS_APPS=gui,drivers.bmv2,pipelines.fabric,segmentrouting,lldpprovider,hostprovider \
 	  -p 8101:8101 -p 8181:8181 \
-	  onosproject/onos:2.1.0
+	  onosproject/onos:2.2.x
 
 onos-cli:
 	ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -p 8101 onos@localhost


### PR DESCRIPTION
Fixing host.docker.internal
- For p4rt-shell and gnmi-cli, use host networking
- For onos, use container that has patch /etc/hosts

fixes #1 
fixes #2 